### PR TITLE
Fixes #1 - Added switch case to determine path

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/helper-module-imports": "^7.0.0"
   },
   "peerDependencies": {
-    "antd": ">3",
+    "antd": ">3.0.0",
     "babel-plugin-macros": ">2.0.0"
   }
 }

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -20,7 +20,7 @@ function importStyle(
   let newName = component.toLowerCase();
   switch (newName) {
     case 'datepicker':
-      component = 'date-picker';
+      newName = 'date-picker';
       break;
     case 'timepicker':
       newName = 'time-picker';

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -17,7 +17,33 @@ function importStyle(
   path: NodePath<t.Identifier>,
   config: Config
 ) {
-  let stylePath = `antd/es/${component.toLowerCase()}/style`;
+  let newName = component.toLowerCase();
+  switch (newName) {
+    case 'datepicker':
+      component = 'date-picker';
+      break;
+    case 'timepicker':
+      newName = 'time-picker';
+      break;
+    case 'autocomplete':
+      newName = 'auto-complete';
+      break;
+    case 'configprovider':
+      newName = 'config-provider';
+      break;
+    case 'inputnumber':
+      newName = 'input-number';
+      break;
+    case 'pageheader':
+      newName = 'page-header';
+      break;
+    case 'treeselect':
+      newName = 'tree-select';
+      break;
+    default:
+      break;
+  }
+  let stylePath = `antd/es/${newName}/style`;
   if (config.style === 'css') {
     stylePath = join(stylePath, 'css');
   }

--- a/tests/fixtures/simple/code.js
+++ b/tests/fixtures/simple/code.js
@@ -1,4 +1,5 @@
-import { Button, Select as MySelect } from '../../../lib/macro';
+import { Button, Select as MySelect, DatePicker } from '../../../lib/macro';
 
 console.log(Button);
 console.log(MySelect);
+console.log(DatePicker);

--- a/tests/fixtures/simple/code.js
+++ b/tests/fixtures/simple/code.js
@@ -1,4 +1,4 @@
-import { Button, Select as MySelect, DatePicker } from '../../../lib/macro';
+import { Button, Select as MySelect, DatePicker } from "../../../lib/macro";
 
 console.log(Button);
 console.log(MySelect);

--- a/tests/fixtures/simple/output.js
+++ b/tests/fixtures/simple/output.js
@@ -1,5 +1,7 @@
-import "antd/es/select/style/css";
-import "antd/es/button/style/css";
-import { Button, Select as MySelect } from "antd";
+import 'antd/es/date-picker/style/css';
+import 'antd/es/select/style/css';
+import 'antd/es/button/style/css';
+import { Button, Select as MySelect, DatePicker } from 'antd';
 console.log(Button);
 console.log(MySelect);
+console.log(DatePicker);

--- a/tests/fixtures/simple/output.js
+++ b/tests/fixtures/simple/output.js
@@ -1,7 +1,7 @@
-import 'antd/es/date-picker/style/css';
-import 'antd/es/select/style/css';
-import 'antd/es/button/style/css';
-import { Button, Select as MySelect, DatePicker } from 'antd';
+import "antd/es/date-picker/style/css";
+import "antd/es/select/style/css";
+import "antd/es/button/style/css";
+import { Button, Select as MySelect, DatePicker } from "antd";
 console.log(Button);
 console.log(MySelect);
 console.log(DatePicker);


### PR DESCRIPTION
Added a switch case to determine the correct path for components with `-` in the path.
Also changed the `peerDependencies` for `antd` since it showed up as an error when installing the macro.